### PR TITLE
TEIIDTOOLS-780: ENTESB-11246: Upgrading the Teiid to 12.3.0 and Teiid…

### DIFF
--- a/komodo-server/src/test/resources/generated-pom.xml
+++ b/komodo-server/src/test/resources/generated-pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <version.springboot.teiid>
-      1.2.0-SNAPSHOT
+      1.2.0
     </version.springboot.teiid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.mysql>8.0.17</version.mysql>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>teiid-spring-boot-starter</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.2.0</version>
     </dependency>
 	<dependency>
 	  <groupId>io.opentracing.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     
     <!-- <spring-cloud.version>Dalston.SR5</spring-cloud.version> -->
     
-    <version.org.teiid>12.3.0-SNAPSHOT</version.org.teiid>
+    <version.org.teiid>12.3.0</version.org.teiid>
 
     <!-- Instruct the build to use only UTF-8 encoding for source code -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -250,7 +250,7 @@
     <!-- DO NOT CHANGE VERSION PROPETY NAMES, THESE ARE USED IN CODE At komodo-rest/template-pom.xml -->
     <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
     <!-- this is simply a version no dependencies involved right now -->
-    <version.springboot.teiid>1.2.0-SNAPSHOT</version.springboot.teiid>
+    <version.springboot.teiid>1.2.0</version.springboot.teiid>
     <version.mysql>8.0.17</version.mysql>
     <version.org.mongodb>3.6.3</version.org.mongodb>
     <version.postgresql>42.1.4</version.postgresql>


### PR DESCRIPTION
… Spring Boot to 1.2.0. Also fixing the an error that shows a failed state during the publish operation due to the timing issues. The for timing issue is to give a grace period of 15 seconds after build completion, and before failure can be detmined if the deployment is available or not. This should be sufficient time for other threads and OpenShift to configure a DeplymentConfig for published artifact