### PR TITLE
TEIIDTOOLS-728 initial single virtualization export

### DIFF
--- a/komodo-server/src/main/java/org/komodo/metadata/TeiidDataSource.java
+++ b/komodo-server/src/main/java/org/komodo/metadata/TeiidDataSource.java
@@ -23,7 +23,7 @@ public interface TeiidDataSource {
 
     String getTranslatorName();
 
-    String getId();
+    String getSyndesisId();
 
     Object getConnectionFactory();
 

--- a/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidDataSourceImpl.java
+++ b/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidDataSourceImpl.java
@@ -90,7 +90,7 @@ public class TeiidDataSourceImpl implements Comparable<TeiidDataSourceImpl>, Tei
     }
 
     @Override
-    public String getId() {
+    public String getSyndesisId() {
         return this.id;
     }
 

--- a/komodo-server/src/main/java/org/komodo/openshift/TeiidOpenShiftClient.java
+++ b/komodo-server/src/main/java/org/komodo/openshift/TeiidOpenShiftClient.java
@@ -17,33 +17,11 @@
  */
 package org.komodo.openshift;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.Reader;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.WeakHashMap;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -97,32 +75,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.builds.Builds;
-import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
-import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildList;
-import io.fabric8.openshift.api.model.DeploymentCondition;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.api.model.DeploymentConfigStatus;
-import io.fabric8.openshift.api.model.ImageStream;
-import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.api.model.RouteList;
-import io.fabric8.openshift.api.model.RouteSpec;
-import io.fabric8.openshift.api.model.TLSConfigBuilder;
+import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -646,7 +604,7 @@ public class TeiidOpenShiftClient implements V1Constants {
             if (tds == null) {
                 return null;
             }
-            return getSyndesisDataSourceById(tds.getId(), true);
+            return getSyndesisDataSourceById(tds.getSyndesisId(), true);
         } catch (Exception e) {
             throw handleError(e);
         }

--- a/komodo-server/src/main/java/org/komodo/rest/V1Constants.java
+++ b/komodo-server/src/main/java/org/komodo/rest/V1Constants.java
@@ -33,7 +33,7 @@ public interface V1Constants extends StringConstants {
         private static final Properties properties = new Properties();
 
         private static void init() {
-            InputStream fileStream = V1Constants.class.getClassLoader().getResourceAsStream("app.properties");
+            InputStream fileStream = V1Constants.class.getClassLoader().getResourceAsStream("app.properties"); //$NON-NLS-1$
 
             try {
                 properties.load(fileStream);
@@ -48,7 +48,7 @@ public interface V1Constants extends StringConstants {
         public static String name() {
             init();
 
-            return properties.getProperty("app.name");
+            return properties.getProperty("app.name"); //$NON-NLS-1$
         }
 
         /**
@@ -57,7 +57,7 @@ public interface V1Constants extends StringConstants {
         public static String title() {
             init();
 
-            return properties.getProperty("app.title");
+            return properties.getProperty("app.title"); //$NON-NLS-1$
         }
 
         /**
@@ -66,7 +66,7 @@ public interface V1Constants extends StringConstants {
         public static String description() {
             init();
 
-            return properties.getProperty("app.description");
+            return properties.getProperty("app.description"); //$NON-NLS-1$
         }
 
         /**
@@ -75,7 +75,7 @@ public interface V1Constants extends StringConstants {
         public static String version() {
             init();
 
-            return properties.getProperty("app.version");
+            return properties.getProperty("app.version"); //$NON-NLS-1$
         }
     }
 
@@ -114,11 +114,6 @@ public interface V1Constants extends StringConstants {
      * The name of the URI path segment for the collection of VDBs in the Komodo workspace.
      */
     String VDBS_SEGMENT = "vdbs"; //$NON-NLS-1$
-
-    /**
-     * The name of the URI path segment for refresh of the preview vdb.
-     */
-    String REFRESH_PREVIEW_VDB_SEGMENT = "refreshPreviewVdb"; //$NON-NLS-1$
 
     /**
      * The name of the URI path segment for the collection of DataServices in the Komodo workspace.

--- a/komodo-server/src/main/java/org/komodo/rest/connections/SyndesisConnectionSynchronizer.java
+++ b/komodo-server/src/main/java/org/komodo/rest/connections/SyndesisConnectionSynchronizer.java
@@ -88,7 +88,7 @@ public class SyndesisConnectionSynchronizer {
             Collection<DefaultSyndesisDataSource> dataSources)
             throws KException {
         Map<String, ? extends TeiidDataSource> existing = openshiftClient
-                .getDataSources().stream().collect(Collectors.toMap(TeiidDataSource::getId, ds->{return ds;}));
+                .getDataSources().stream().collect(Collectors.toMap(TeiidDataSource::getSyndesisId, ds->{return ds;}));
 
         for (DefaultSyndesisDataSource sds : dataSources) {
             existing.remove(sds.getSyndesisConnectionId());
@@ -96,7 +96,7 @@ public class SyndesisConnectionSynchronizer {
         }
 
         for (TeiidDataSource removed : existing.values()) {
-            handleDeleteConnection(removed.getId());
+            handleDeleteConnection(removed.getSyndesisId());
         }
     }
 

--- a/komodo-server/src/main/java/org/komodo/rest/datavirtualization/RestDataVirtualization.java
+++ b/komodo-server/src/main/java/org/komodo/rest/datavirtualization/RestDataVirtualization.java
@@ -40,11 +40,6 @@ public final class RestDataVirtualization {
      */
     public static final String DESCRIPTION_LABEL = "tko__description";
 
-    /**
-     * Label used to describe dataservice viewNames
-     */
-    public static final String DATASERVICE_VIEW_DEFINITIONS_LABEL = "serviceViewDefinitions"; //$NON-NLS-1$
-
     public static final String DATASERVICE_NAME_LABEL = "keng__id"; //$NON-NLS-1$
 
     private String id;

--- a/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/BaseEntityAdapter.java
+++ b/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/BaseEntityAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komodo.rest.datavirtualization.v1;
+
+import java.sql.Timestamp;
+
+import org.komodo.datavirtualization.BaseEntity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class BaseEntityAdapter<T extends BaseEntity> {
+
+    protected T entity;
+
+    protected BaseEntityAdapter(T entity) {
+        this.entity = entity;
+    }
+
+    public Timestamp getCreatedAt() {
+        return entity.getCreatedAt();
+    }
+
+    public String getId() {
+        return entity.getId();
+    }
+
+    public Timestamp getModifiedAt() {
+        return entity.getModifiedAt();
+    }
+
+    public String getName() {
+        return entity.getName();
+    }
+
+    public void setId(String id) {
+        entity.setId(id);
+    }
+
+    public void setName(String name) {
+        entity.setName(name);
+    }
+
+    @JsonIgnore
+    public T getEntity() {
+        return entity;
+    }
+
+}

--- a/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/DataVirtualizationV1Adapter.java
+++ b/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/DataVirtualizationV1Adapter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komodo.rest.datavirtualization.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.komodo.datavirtualization.DataVirtualization;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value=Include.NON_NULL)
+public class DataVirtualizationV1Adapter extends BaseEntityAdapter<DataVirtualization> {
+
+    private List<ViewDefinitionV1Adapter> views = new ArrayList<>();
+    private List<SourceV1> sources = new ArrayList<>();
+
+    public DataVirtualizationV1Adapter() {
+        super(new DataVirtualization(null));
+    }
+
+    public DataVirtualizationV1Adapter(DataVirtualization dv) {
+        super(dv);
+    }
+
+    public String getDescription() {
+        return entity.getDescription();
+    }
+
+    public void setDescription(String description) {
+        entity.setDescription(description);
+    }
+
+    public List<ViewDefinitionV1Adapter> getViews() {
+        return views;
+    }
+
+    public void setViews(List<ViewDefinitionV1Adapter> views) {
+        this.views = views;
+    }
+
+    public List<SourceV1> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<SourceV1> sources) {
+        this.sources = sources;
+    }
+
+}

--- a/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/SourceV1.java
+++ b/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/SourceV1.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komodo.rest.datavirtualization.v1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value=Include.NON_NULL)
+public class SourceV1 {
+
+    private String sourceId;
+    private String name;
+
+    public String getSourceId() {
+        return sourceId;
+    }
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/ViewDefinitionV1Adapter.java
+++ b/komodo-server/src/main/java/org/komodo/rest/datavirtualization/v1/ViewDefinitionV1Adapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komodo.rest.datavirtualization.v1;
+
+import org.komodo.datavirtualization.ViewDefinition;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value=Include.NON_NULL)
+public class ViewDefinitionV1Adapter extends BaseEntityAdapter<ViewDefinition> {
+
+    public ViewDefinitionV1Adapter() {
+        super(new ViewDefinition(null, null));
+    }
+
+    public ViewDefinitionV1Adapter(ViewDefinition vd) {
+        super(vd);
+    }
+
+    public String getDdl() {
+        return entity.getDdl();
+    }
+
+    public void setDdl(String ddl) {
+        entity.setDdl(ddl);
+    }
+
+    public String getDescription() {
+        return entity.getDescription();
+    }
+
+    public void setDescription(String description) {
+        entity.setDescription(description);
+    }
+
+    public boolean isComplete() {
+        return entity.isComplete();
+    }
+
+    public void setComplete(boolean complete) {
+        entity.setComplete(complete);
+    }
+
+    public boolean isUserDefined() {
+        return entity.isUserDefined();
+    }
+
+    public void setUserDefined(boolean userDefined) {
+        entity.setUserDefined(userDefined);
+    }
+
+}

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -19,16 +19,24 @@ package org.komodo.rest.service;
 
 import static org.komodo.rest.datavirtualization.RelationalMessages.Error.*;
 
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 import org.komodo.KException;
 import org.komodo.StringConstants;
 import org.komodo.WorkspaceManager;
 import org.komodo.datavirtualization.DataVirtualization;
+import org.komodo.datavirtualization.SourceSchema;
 import org.komodo.datavirtualization.ViewDefinition;
+import org.komodo.metadata.TeiidDataSource;
 import org.komodo.openshift.BuildStatus;
 import org.komodo.openshift.BuildStatus.RouteStatus;
 import org.komodo.openshift.ProtocolType;
@@ -39,23 +47,38 @@ import org.komodo.rest.datavirtualization.ImportPayload;
 import org.komodo.rest.datavirtualization.KomodoStatusObject;
 import org.komodo.rest.datavirtualization.RelationalMessages;
 import org.komodo.rest.datavirtualization.RestDataVirtualization;
+import org.komodo.rest.datavirtualization.v1.DataVirtualizationV1Adapter;
+import org.komodo.rest.datavirtualization.v1.SourceV1;
+import org.komodo.rest.datavirtualization.v1.ViewDefinitionV1Adapter;
+import org.komodo.utils.PathUtils;
 import org.komodo.utils.StringNameValidator;
 import org.komodo.utils.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.teiid.adminapi.impl.ModelMetaData;
 import org.teiid.metadata.Schema;
 import org.teiid.metadata.Table;
 import org.teiid.util.FullyQualifiedName;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -86,6 +109,9 @@ public final class KomodoDataserviceService extends KomodoService {
 
     @Autowired
     private KomodoMetadataService metadataService;
+
+    @Autowired
+    private KomodoUtilService utilService;
 
     /**
      * Get the Dataservices from the komodo repository
@@ -137,7 +163,7 @@ public final class KomodoDataserviceService extends KomodoService {
             @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
             @ApiResponse(code = 403, message = "An error has occurred.") })
     public RestDataVirtualization getDataservice(
-            @ApiParam(value = "Id of the dataservice to be fetched, ie. the value of the 'keng__id' property",
+            @ApiParam(value = "name of the dataservice to be fetched",
             required = true) final @PathVariable("dataserviceName") String dataserviceName)
             throws Exception {
 
@@ -437,6 +463,152 @@ public final class KomodoDataserviceService extends KomodoService {
 
             return kso;
         });
+    }
+
+    @RequestMapping(value = V1Constants.DATA_SERVICE_PLACEHOLDER + FS + "export", method = RequestMethod.GET, produces = {
+            MediaType.MULTIPART_FORM_DATA_VALUE })
+    @ApiOperation(value = "Find dataservice by name", response = RestDataVirtualization.class)
+    @ApiResponses(value = { @ApiResponse(code = 404, message = "No Dataservice could be found with name"),
+            @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+            @ApiResponse(code = 403, message = "An error has occurred.") })
+    public ResponseEntity<StreamingResponseBody> exportDataservice(
+            @ApiParam(value = "name of the dataservice",
+            required = true) final @PathVariable("dataserviceName") String dataserviceName)
+            throws Exception {
+
+        DataVirtualizationV1Adapter result = kengine.runInTransaction(true, () -> {
+            DataVirtualization dv = getWorkspaceManager().findDataVirtualization(dataserviceName);
+
+            if (dv == null) {
+                throw notFound(dataserviceName);
+            }
+
+            DataVirtualizationV1Adapter adapter = new DataVirtualizationV1Adapter(dv);
+
+            List<? extends ViewDefinition> views = getWorkspaceManager().findViewDefinitions(dataserviceName);
+
+            Map<String, SourceV1> sources = new LinkedHashMap<>();
+
+            for (ViewDefinition view : views) {
+                adapter.getViews().add(new ViewDefinitionV1Adapter(view));
+                for (String path : view.getSourcePaths()) {
+                    String connection = PathUtils.getOptions(path).get(0).getSecond();
+                    if (sources.containsKey(connection)) {
+                        continue;
+                    }
+                    TeiidDataSource tds = this.metadataService.findTeiidDatasource(connection);
+                    if (tds != null) {
+                        SourceV1 source = new SourceV1();
+                        source.setSourceId(tds.getSyndesisId());
+                        source.setName(tds.getName());
+                        sources.put(connection, source);
+                    }
+                }
+            }
+
+            adapter.setSources(new ArrayList<>(sources.values()));
+
+            return adapter;
+        });
+
+        StreamingResponseBody stream = out -> {
+            ZipOutputStream zos = new ZipOutputStream(out);
+
+            JsonFactory jsonFactory = new JsonFactory();
+            jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+            ObjectMapper mapper = new ObjectMapper(jsonFactory);
+
+            zos.putNextEntry(new ZipEntry("dv.json")); //$NON-NLS-1$
+            mapper.writerWithDefaultPrettyPrinter().writeValue(zos, result);
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("dv-info.json")); //$NON-NLS-1$
+            zos.write("{\"version\":1}".getBytes("UTF-8")); //$NON-NLS-1$ //$NON-NLS-2$
+            zos.closeEntry();
+
+            zos.close();
+        };
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Content-Disposition", "attachment; filename=\""+dataserviceName+"-export.zip\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        return new ResponseEntity<StreamingResponseBody>(stream, headers, HttpStatus.OK);
+    }
+
+    @PostMapping()
+    @ApiOperation(value = "Import a single data virtualization", response = String.class)
+    public ResponseEntity<KomodoStatusObject> importDataservice(@ApiParam(value = "name of the dataservice")
+            @RequestParam(name="virtualization", required=false) String virtualization,
+            @RequestParam("file") MultipartFile file) throws Exception {
+
+        final DataVirtualizationV1Adapter dv;
+        try (InputStream is = file.getInputStream();) {
+            ZipInputStream zis = new ZipInputStream(is);
+
+            ZipEntry ze = zis.getNextEntry();
+            while (ze != null && !ze.getName().equals("dv.json")) {
+                ze = zis.getNextEntry();
+            }
+            if (ze == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "zip does not contain dv.json");
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            dv = mapper.readValue(zis, DataVirtualizationV1Adapter.class);
+        }
+
+        DataVirtualization toImport = dv.getEntity();
+        if (virtualization == null) {
+            virtualization = toImport.getName();
+        } else {
+            toImport.setName(virtualization);
+        }
+
+        //TODO: validate the uuid or assign a new one
+        //for now we just assign new to all objects
+
+        for (ViewDefinitionV1Adapter adapter : dv.getViews()) {
+            ViewDefinition entity = adapter.getEntity();
+            entity.setId(null);
+            entity.setDataVirtualizationName(virtualization);
+        }
+
+        KomodoStatusObject kso = new KomodoStatusObject("import result"); //$NON-NLS-1$
+
+        try {
+            kengine.runInTransaction(false, () -> {
+                for (SourceV1 source : dv.getSources()) {
+                    TeiidDataSource tds = metadataService.findTeiidDatasource(source.getName());
+                    if (tds == null) {
+                        //nothing with this name, check by id
+                        SourceSchema schema = getWorkspaceManager().findSchemaBySourceId(source.getSourceId());
+                        if (schema != null) {
+                            kso.addAttribute(source.getName(), "a syndesis connection exists with the given id, but does not match the name"); //$NON-NLS-1$
+                        } else {
+                            kso.addAttribute(source.getName(), "no syndesis connection can be found"); //$NON-NLS-1$
+                        }
+                    } else {
+                        if (tds.getSyndesisId().equals(source.getSourceId())) {
+                            //presumably everything checks out
+                            //however it seems like syndesis connection ids are simply sequential,
+                            //so they may not be consistent across environments
+                        } else {
+                            kso.addAttribute(source.getName(), "a syndesis connection with the same name exists, but the ids do not match"); //$NON-NLS-1$
+                        }
+                    }
+                }
+                createDataservice(toImport.getName(), new RestDataVirtualization(toImport));
+
+                for (ViewDefinitionV1Adapter adapter : dv.getViews()) {
+                    ViewDefinition vd = adapter.getEntity();
+                    utilService.upsertViewEditorState(vd);
+                }
+                return null;
+            });
+        } catch (DataIntegrityViolationException e) {
+            throw error(HttpStatus.CONFLICT, RelationalMessages.Error.DATASERVICE_SERVICE_CREATE_ALREADY_EXISTS);
+        }
+
+        return new ResponseEntity<KomodoStatusObject>(kso, HttpStatus.OK);
     }
 
 }

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
@@ -480,7 +480,7 @@ public class KomodoMetadataService extends KomodoService implements ServiceVdbGe
                 TeiidDataSource teiidSource = getMetadataInstance().getDataSource(komodoName);
                 RestSyndesisSourceStatus status = new RestSyndesisSourceStatus(komodoName);
                 if (teiidSource != null) {
-                    setSchemaStatus(teiidSource.getId(), status);
+                    setSchemaStatus(teiidSource.getSyndesisId(), status);
                 }
 
                 // Name of vdb based on source name
@@ -562,7 +562,7 @@ public class KomodoMetadataService extends KomodoService implements ServiceVdbGe
         // VDB is created in the repository.  If it already exists, delete it
         final WorkspaceManager mgr = this.getWorkspaceManager();
 
-        SourceSchema schema = mgr.findSchemaBySourceId(teiidSource.getId());
+        SourceSchema schema = mgr.findSchemaBySourceId(teiidSource.getSyndesisId());
         if (schema == null) {
             //something is wrong, the logic that creates TeiidDataSources will always ensure
             //a sourceschema is created
@@ -644,7 +644,7 @@ public class KomodoMetadataService extends KomodoService implements ServiceVdbGe
         ModelMetaData mmd = new ModelMetaData();
         mmd.setName(sourceName);
         vdb.addModel(mmd);
-        vdb.addProperty(TeiidOpenShiftClient.ID, teiidSource.getId());
+        vdb.addProperty(TeiidOpenShiftClient.ID, teiidSource.getSyndesisId());
         mmd.setModelType(Type.PHYSICAL);
 
         for (Map.Entry<String,String> entry : teiidSource.getImportProperties().entrySet()) {
@@ -653,7 +653,7 @@ public class KomodoMetadataService extends KomodoService implements ServiceVdbGe
 
         if (schema != null) {
             //use this instead
-            mmd.addSourceMetadata(DDLDBMetadataRepository.TYPE_NAME, teiidSource.getId());
+            mmd.addSourceMetadata(DDLDBMetadataRepository.TYPE_NAME, teiidSource.getSyndesisId());
             mmd.setVisible(false);
         } else {
             vdb.addProperty("async-load", "true"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -43,9 +43,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.teiid.metadata.AbstractMetadataRecord;
 import org.teiid.metadata.Schema;
 import org.teiid.metadata.Table;
 import org.teiid.query.validator.ValidatorReport;
+import org.teiid.util.FullyQualifiedName;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -294,6 +296,15 @@ public final class KomodoUtilService extends KomodoService {
             viewDefnStatus.setStatus(ERROR);
             viewDefnStatus.setMessage(errorMsg);
         } else {
+            restViewDefinition.getSourcePaths().clear();
+            for (AbstractMetadataRecord r : t.getIncomingObjects()) {
+                if (r instanceof Table) {
+                    //TODO: should system stuff be filtered
+                    FullyQualifiedName fqn = new FullyQualifiedName(Schema.getTypeName(), r.getParent().getName());
+                    fqn.append(Schema.getChildType(Table.class), r.getName());
+                    restViewDefinition.addSourcePath(fqn.toString());
+                }
+            }
             String error = report.getFailureMessage();
             if (report.hasItems() && !error.isEmpty()) {
                 viewDefnStatus.setStatus(ERROR);


### PR DESCRIPTION
Here is the single data virtualization import/export.  It uses:

get .../dataservices/name/export
post .../dataservices/import?virtualization=name

The import/export format is a zip file containing a dv.json and a dv-info.json file - which is basically the same approach as syndesis.  We don't yet need any handling of versioning beyond the usage of the adapter classes which means that we can change the other service methods and/or the database and not disturb the import/export format.

The get method does seem problematic - as described in another issue - it seems like gets under an resource path should be for that object or child information.  So it could just as easily be a post or moved to it's own service (I recall that komodo had an import/export service).

This does not attempt to resolve any differences in the declared sources and what exists - it will just note the differences in the status returned by import.  At worst the imported virtualization will just have a bunch of errors.  We may eventually need to update the sql if the name of a given connection has changed between environments.  Another simplifying assumption is that everything gets a new uuid, rather than only creating on conflict.

Before we implement the bulk import/export, we need to add the labeling functionality.

This also contains a small fix of the 404 for getDataservice.