### PR TITLE
TEIIDTOOLS-737 deprecating the validation methods

### DIFF
--- a/komodo-core/src/main/java/org/komodo/WorkspaceManager.java
+++ b/komodo-core/src/main/java/org/komodo/WorkspaceManager.java
@@ -48,6 +48,8 @@ public interface WorkspaceManager {
 
     DataVirtualization findDataVirtualization(String virtualizationName);
 
+    DataVirtualization findDataVirtualizationByNameIgnoreCase(String virtualizationName);
+
     DataVirtualization findDataVirtualizationBySourceId(String sourceId);
 
     public Iterable<? extends DataVirtualization> findDataVirtualizations();

--- a/komodo-core/src/main/java/org/komodo/repository/DataVirtualizationRepository.java
+++ b/komodo-core/src/main/java/org/komodo/repository/DataVirtualizationRepository.java
@@ -39,4 +39,8 @@ public interface DataVirtualizationRepository extends JpaRepository<DataVirtuali
 
     @Query(value = "from DataVirtualization where source_id = :sourceId")
     public DataVirtualization findBySourceId(@Param("sourceId") String sourceId);
+
+    @Query("from DataVirtualization dv where dv.upperName = UPPER(:dvName)")
+    public DataVirtualization findByNameIgnoreCase(@Param("dvName") String dvName);
+
 }

--- a/komodo-core/src/main/java/org/komodo/repository/WorkspaceManagerImpl.java
+++ b/komodo-core/src/main/java/org/komodo/repository/WorkspaceManagerImpl.java
@@ -91,6 +91,12 @@ public class WorkspaceManagerImpl implements WorkspaceManager {
     }
 
     @Override
+    public DataVirtualization findDataVirtualizationByNameIgnoreCase(
+            String virtualizationName) {
+        return this.dataVirtualizationRepository.findByNameIgnoreCase(virtualizationName);
+    }
+
+    @Override
     public Iterable<? extends DataVirtualization> findDataVirtualizations() {
         return this.dataVirtualizationRepository.findAll();
     }

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -654,8 +654,7 @@ public final class KomodoDataserviceService extends KomodoService {
     @ApiResponses( value = {
             @ApiResponse( code = 400, message = "The URI cannot contain encoded slashes or backslashes." ),
             @ApiResponse( code = 403, message = "An unexpected error has occurred." ),
-            @ApiResponse( code = 404, message = "No view could be found with name" ),
-            @ApiResponse( code = 500, message = "The view name cannot be empty." )
+            @ApiResponse( code = 404, message = "No view could be found with name" )
     } )
     public ViewDefinition getViewDefinition(
                                       @ApiParam(value = "Name of the virtualization", required = true)
@@ -670,9 +669,15 @@ public final class KomodoDataserviceService extends KomodoService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, errorMsg);
         }
 
-        return kengine.runInTransaction(true, ()-> {
+        ViewDefinition vd = kengine.runInTransaction(true, ()-> {
             return getWorkspaceManager().findViewDefinitionByNameIgnoreCase(virtualization, viewName);
         });
+
+        if (vd == null) {
+            throw notFound(viewName);
+        }
+
+        return vd;
     }
 
 }

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -50,6 +50,7 @@ import org.komodo.rest.datavirtualization.RestDataVirtualization;
 import org.komodo.rest.datavirtualization.v1.DataVirtualizationV1Adapter;
 import org.komodo.rest.datavirtualization.v1.SourceV1;
 import org.komodo.rest.datavirtualization.v1.ViewDefinitionV1Adapter;
+import org.komodo.utils.KLog;
 import org.komodo.utils.PathUtils;
 import org.komodo.utils.StringNameValidator;
 import org.komodo.utils.StringUtils;
@@ -142,12 +143,14 @@ public final class KomodoDataserviceService extends KomodoService {
         entity.setServiceViewModel(dataService.getName());
         // Set published status of dataservice
         BuildStatus status = this.openshiftClient.getVirtualizationStatus(dataService.getName());
-        entity.setPublishedState(status.status().name());
-        entity.setPublishPodName(status.publishPodName());
-        entity.setPodNamespace(status.namespace());
-        entity.setOdataHostName(getOdataHost(status));
+        if (status != null) {
+            entity.setPublishedState(status.status().name());
+            entity.setPublishPodName(status.publishPodName());
+            entity.setPodNamespace(status.namespace());
+            entity.setOdataHostName(getOdataHost(status));
+            entity.setUsedBy(status.getUsedBy());
+        }
         entity.setEmpty(this.getWorkspaceManager().findViewDefinitionsNames(dataService.getName()).isEmpty());
-        entity.setUsedBy(status.getUsedBy());
         return entity;
     }
 
@@ -168,10 +171,15 @@ public final class KomodoDataserviceService extends KomodoService {
             throws Exception {
 
         DataVirtualization dv = kengine.runInTransaction(true, () -> {
-             return getWorkspaceManager().findDataVirtualization(dataserviceName);
+             return getWorkspaceManager().findDataVirtualizationByNameIgnoreCase(dataserviceName);
         });
 
         if (dv == null) {
+            String validationMessage = getValidationMessage(dataserviceName);
+            if (validationMessage != null) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, validationMessage);
+            }
+
             throw notFound( dataserviceName );
         }
 
@@ -271,6 +279,7 @@ public final class KomodoDataserviceService extends KomodoService {
      *         an empty string, when the name is valid, or an error message
      * @throws Exception
      */
+    @Deprecated
     @RequestMapping(value = V1Constants.NAME_VALIDATION_SEGMENT + FS
             + V1Constants.DATA_SERVICE_PLACEHOLDER, method = RequestMethod.GET, produces = { "text/plain" })
     @ApiOperation(value = "Returns an error message if the data service name is invalid")
@@ -279,6 +288,8 @@ public final class KomodoDataserviceService extends KomodoService {
             @ApiResponse(code = 403, message = "An unexpected error has occurred."),
             @ApiResponse(code = 500, message = "The dataservice name cannot be empty.") })
     public ResponseEntity<String> validateDataserviceName(@ApiParam(value = "The dataservice name being checked", required = true) final @PathVariable("dataserviceName") String dataserviceName) throws Exception {
+
+        KLog.getLogger().warn("validateDataserviceName is deprecated, use GET dataservices/{name} instead"); //$NON-NLS-1$
 
         String validationMessage = getValidationMessage(dataserviceName);
         if (validationMessage != null) {
@@ -465,6 +476,12 @@ public final class KomodoDataserviceService extends KomodoService {
         });
     }
 
+    /**
+     * Export the virtualization to a zip file
+     * @param dataserviceName
+     * @return
+     * @throws Exception
+     */
     @RequestMapping(value = V1Constants.DATA_SERVICE_PLACEHOLDER + FS + "export", method = RequestMethod.GET, produces = {
             MediaType.MULTIPART_FORM_DATA_VALUE })
     @ApiOperation(value = "Find dataservice by name", response = RestDataVirtualization.class)
@@ -533,6 +550,13 @@ public final class KomodoDataserviceService extends KomodoService {
         return new ResponseEntity<StreamingResponseBody>(stream, headers, HttpStatus.OK);
     }
 
+    /**
+     * Import a virtualization from a zip file
+     * @param virtualization
+     * @param file
+     * @return
+     * @throws Exception
+     */
     @PostMapping()
     @ApiOperation(value = "Import a single data virtualization", response = String.class)
     public ResponseEntity<KomodoStatusObject> importDataservice(@ApiParam(value = "name of the dataservice")
@@ -544,11 +568,11 @@ public final class KomodoDataserviceService extends KomodoService {
             ZipInputStream zis = new ZipInputStream(is);
 
             ZipEntry ze = zis.getNextEntry();
-            while (ze != null && !ze.getName().equals("dv.json")) {
+            while (ze != null && !ze.getName().equals("dv.json")) { //$NON-NLS-1$
                 ze = zis.getNextEntry();
             }
             if (ze == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "zip does not contain dv.json");
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "zip does not contain dv.json"); //$NON-NLS-1$
             }
 
             ObjectMapper mapper = new ObjectMapper();
@@ -609,6 +633,34 @@ public final class KomodoDataserviceService extends KomodoService {
         }
 
         return new ResponseEntity<KomodoStatusObject>(kso, HttpStatus.OK);
+    }
+
+    @RequestMapping( value = V1Constants.DATA_SERVICE_PLACEHOLDER + "/views/{viewName}", method = RequestMethod.GET, produces = {
+            MediaType.APPLICATION_JSON_VALUE })
+    @ApiOperation(value = "Returns the view with the given name",
+    response = ViewDefinition.class)
+    @ApiResponses( value = {
+            @ApiResponse( code = 400, message = "The URI cannot contain encoded slashes or backslashes." ),
+            @ApiResponse( code = 403, message = "An unexpected error has occurred." ),
+            @ApiResponse( code = 404, message = "No view could be found with name" ),
+            @ApiResponse( code = 500, message = "The view name cannot be empty." )
+    } )
+    public ViewDefinition getViewDefinition(
+                                      @ApiParam(value = "Name of the virtualization", required = true)
+                                      final @PathVariable( "dataserviceName" ) String virtualization,
+                                      @ApiParam(value = "Name of the view - not case sensitive", required = true)
+                                      final @PathVariable( "viewName" ) String viewName ) throws Exception {
+
+        final String errorMsg = VALIDATOR.checkValidName( viewName );
+
+        // a name validation error occurred
+        if ( errorMsg != null ) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, errorMsg);
+        }
+
+        return kengine.runInTransaction(true, ()-> {
+            return getWorkspaceManager().findViewDefinitionByNameIgnoreCase(virtualization, viewName);
+        });
     }
 
 }

--- a/komodo-server/src/main/java/org/komodo/rest/service/KomodoVdbService.java
+++ b/komodo-server/src/main/java/org/komodo/rest/service/KomodoVdbService.java
@@ -23,6 +23,7 @@ import org.komodo.datavirtualization.ViewDefinition;
 import org.komodo.rest.KomodoService;
 import org.komodo.rest.V1Constants;
 import org.komodo.rest.datavirtualization.RelationalMessages;
+import org.komodo.utils.KLog;
 import org.komodo.utils.StringNameValidator;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -39,6 +40,7 @@ import io.swagger.annotations.ApiResponses;
 /**
  * A Komodo REST service for obtaining VDB information from the workspace.
  */
+@Deprecated
 @RestController
 @RequestMapping(V1Constants.APP_PATH + V1Constants.FS + V1Constants.WORKSPACE_SEGMENT)
 @Api(tags = {V1Constants.VDBS_SEGMENT})
@@ -70,6 +72,8 @@ public final class KomodoVdbService extends KomodoService {
                                       final @PathVariable( "virtualization" ) String virtualization,
                                       @ApiParam(value = "Name of the Model to get its tables", required = true)
                                       final @PathVariable( "viewName" ) String viewName ) throws Exception {
+
+        KLog.getLogger().warn("validateViewName is deprecated, use GET workspace/dataservices/{virtualization}/views/{viewName} instead");
 
         final String errorMsg = VALIDATOR.checkValidName( viewName );
 

--- a/komodo-server/src/test/java/org/komodo/rest/service/IntegrationTest.java
+++ b/komodo-server/src/test/java/org/komodo/rest/service/IntegrationTest.java
@@ -156,6 +156,11 @@ public class IntegrationTest {
                 "/v1/workspace/dataservices/dv", rdv, String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
+        ResponseEntity<ViewDefinition> validateViewName = restTemplate.getForEntity(
+                "/v1/workspace/dataservices/{virtualization}/views/{viewName}",
+                ViewDefinition.class, dvName, "myView");
+        assertEquals(HttpStatus.NOT_FOUND, validateViewName.getStatusCode());
+
         ViewDefinition vd = new ViewDefinition(dvName, "myview");
         vd.setComplete(true);
         vd.setDdl("create view myview as select 1 as col");
@@ -204,7 +209,7 @@ public class IntegrationTest {
         //means that it's not valid
         assertNotNull(validate.getBody());
 
-        ResponseEntity<ViewDefinition> validateViewName = restTemplate.getForEntity(
+        validateViewName = restTemplate.getForEntity(
                 "/v1/workspace/dataservices/{virtualization}/views/{viewName}",
                 ViewDefinition.class, dvName, "myView");
         assertEquals(HttpStatus.OK, validateViewName.getStatusCode());

--- a/komodo-server/src/test/java/org/komodo/rest/service/IntegrationTest.java
+++ b/komodo-server/src/test/java/org/komodo/rest/service/IntegrationTest.java
@@ -201,7 +201,15 @@ public class IntegrationTest {
                 "/v1/workspace/{virtualization}/views/nameValidation/{viewName}",
                 String.class, dvName, "myView");
         assertEquals(HttpStatus.OK, validate.getStatusCode());
+        //means that it's not valid
         assertNotNull(validate.getBody());
+
+        ResponseEntity<ViewDefinition> validateViewName = restTemplate.getForEntity(
+                "/v1/workspace/dataservices/{virtualization}/views/{viewName}",
+                ViewDefinition.class, dvName, "myView");
+        assertEquals(HttpStatus.OK, validateViewName.getStatusCode());
+        //means that it already exists, therefore not valid
+        assertNotNull(validateViewName.getBody());
 
         query("select * from dv.myview", dvName, true);
 

--- a/komodo-server/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/komodo-server/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -18,11 +18,7 @@
 
 package org.komodo.rest.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -40,9 +36,11 @@ import org.komodo.repository.WorkspaceManagerImpl;
 import org.komodo.rest.KomodoJsonMarshaller;
 import org.komodo.rest.datavirtualization.ImportPayload;
 import org.komodo.rest.datavirtualization.KomodoStatusObject;
+import org.komodo.rest.datavirtualization.RestDataVirtualization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -156,6 +154,37 @@ public class KomodoDataserviceServiceTest {
         //conflicts
         response = komodoDataserviceService.validateDataserviceName("FOO");
         assertNotNull(response.getBody());
+    }
+
+    @Test public void testValidateNameUsingGet() throws Exception {
+        try {
+            komodoDataserviceService.getDataservice("foo");
+            fail();
+        } catch (ResponseStatusException e) {
+            assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+        }
+
+        //must end with number/letter
+        try {
+            komodoDataserviceService.getDataservice("foo-");
+            fail();
+        } catch (ResponseStatusException e) {
+            assertEquals(HttpStatus.FORBIDDEN, e.getStatus());
+        }
+
+        //bad chars
+        try {
+            komodoDataserviceService.getDataservice("%foo&");
+            fail();
+        } catch (ResponseStatusException e) {
+            assertEquals(HttpStatus.FORBIDDEN, e.getStatus());
+        }
+
+        workspaceManagerImpl.createDataVirtualization("foo");
+
+        //conflicts
+        RestDataVirtualization response = komodoDataserviceService.getDataservice("FOO");
+        assertNotNull(response);
     }
 
     static DefaultSyndesisDataSource createH2DataSource(String name) {


### PR DESCRIPTION
This makes the validation change mentioned on TEIIDTOOLS-737.  Once the ui is changed, we can then remove the KomodoVdbService.